### PR TITLE
Bring back MaxBy & MinBy

### DIFF
--- a/src/MoreAsyncLINQ/MoreAsyncLINQ.csproj
+++ b/src/MoreAsyncLINQ/MoreAsyncLINQ.csproj
@@ -25,13 +25,13 @@ Modernize API &amp; implementation:
 
 Breaking Changes:
 - PartitionAsync now returns a `ValueTask&lt;(IEnumerable&lt;TSource&gt; True, IEnumerable&lt;TSource&gt; False)&gt;` instead of a `ValueTask&lt;(IAsyncEnumerable&lt;TSource&gt; True, IAsyncEnumerable&lt;TSource&gt; False)&gt;`
-- Hide CountBy, DistinctBy, Index, MaxBy, MinBy, SkipLast, TakeLast &amp; ToDictionary since they're included in .NET</PackageReleaseNotes>
+- Hide CountBy, DistinctBy, Index, SkipLast, TakeLast &amp; ToDictionary since they're included in .NET</PackageReleaseNotes>
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <PackageTags>linq;async</PackageTags>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <TargetFrameworks>net462;netstandard2.0;net8.0;net9.0;net10.0</TargetFrameworks>
-    <Version>2.0.0-preview.1</Version>
+    <Version>2.0.0-preview.2</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/MoreAsyncLINQ/Operators/ExtremaBy/MaxBy.cs
+++ b/src/MoreAsyncLINQ/Operators/ExtremaBy/MaxBy.cs
@@ -22,15 +22,14 @@ static partial class MoreAsyncEnumerable
     /// <param name="selector">Selector to use to pick the results to compare</param>
     /// <returns>The sequence of maximal elements, according to the projection.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="selector"/> is null</exception>
-    [Obsolete($"Use an overload of {nameof(Maxima)}.")]
     public static IExtremaAsyncEnumerable<TSource> MaxBy<TSource, TKey>(
-        IAsyncEnumerable<TSource> source,
+        this IAsyncEnumerable<TSource> source,
         Func<TSource, TKey> selector)
     {
         if (source is null) throw new ArgumentNullException(nameof(source));
         if (selector is null) throw new ArgumentNullException(nameof(selector));
 
-        return MaxBy(source, selector, comparer: null);
+        return source.MaxBy(selector, comparer: null);
     }
 
     /// <summary>
@@ -49,9 +48,8 @@ static partial class MoreAsyncEnumerable
     /// <returns>The sequence of maximal elements, according to the projection.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="source"/>, <paramref name="selector"/>
     /// or <paramref name="comparer"/> is null</exception>
-    [Obsolete($"Use an overload of {nameof(Maxima)}.")]
     public static IExtremaAsyncEnumerable<TSource> MaxBy<TSource, TKey>(
-        IAsyncEnumerable<TSource> source,
+        this IAsyncEnumerable<TSource> source,
         Func<TSource, TKey> selector,
         IComparer<TKey>? comparer)
     {
@@ -81,7 +79,7 @@ static partial class MoreAsyncEnumerable
     /// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="selector"/> is null</exception>
     [Obsolete($"Use an overload of {nameof(Maxima)} that accepts an async delegate with a {nameof(CancellationToken)} parameter.")]
     public static IExtremaAsyncEnumerable<TSource> MaxByAwait<TSource, TKey>(
-        IAsyncEnumerable<TSource> source,
+        this IAsyncEnumerable<TSource> source,
         Func<TSource, ValueTask<TKey>> selector)
     {
         if (source is null) throw new ArgumentNullException(nameof(source));
@@ -108,7 +106,7 @@ static partial class MoreAsyncEnumerable
     /// or <paramref name="comparer"/> is null</exception>
     [Obsolete($"Use an overload of {nameof(Maxima)} that accepts an async delegate with a {nameof(CancellationToken)} parameter.")]
     public static IExtremaAsyncEnumerable<TSource> MaxByAwait<TSource, TKey>(
-        IAsyncEnumerable<TSource> source,
+        this IAsyncEnumerable<TSource> source,
         Func<TSource, ValueTask<TKey>> selector,
         IComparer<TKey>? comparer)
     {

--- a/src/MoreAsyncLINQ/Operators/ExtremaBy/MinBy.cs
+++ b/src/MoreAsyncLINQ/Operators/ExtremaBy/MinBy.cs
@@ -22,15 +22,14 @@ static partial class MoreAsyncEnumerable
     /// <param name="selector">Selector to use to pick the results to compare</param>
     /// <returns>The sequence of minimal elements, according to the projection.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="selector"/> is null</exception>
-    [Obsolete($"Use an overload of {nameof(Minima)}.")]
     public static IExtremaAsyncEnumerable<TSource> MinBy<TSource, TKey>(
-        IAsyncEnumerable<TSource> source,
+        this IAsyncEnumerable<TSource> source,
         Func<TSource, TKey> selector)
     {
         if (source is null) throw new ArgumentNullException(nameof(source));
         if (selector is null) throw new ArgumentNullException(nameof(selector));
 
-        return MinBy(source, selector, comparer: null);
+        return source.MinBy(selector, comparer: null);
     }
 
     /// <summary>
@@ -49,9 +48,8 @@ static partial class MoreAsyncEnumerable
     /// <returns>The sequence of minimal elements, according to the projection.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="source"/>, <paramref name="selector"/>
     /// or <paramref name="comparer"/> is null</exception>
-    [Obsolete($"Use an overload of {nameof(Minima)}.")]
     public static IExtremaAsyncEnumerable<TSource> MinBy<TSource, TKey>(
-        IAsyncEnumerable<TSource> source,
+        this IAsyncEnumerable<TSource> source,
         Func<TSource, TKey> selector,
         IComparer<TKey>? comparer)
     {
@@ -81,7 +79,7 @@ static partial class MoreAsyncEnumerable
     /// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="selector"/> is null</exception>
     [Obsolete($"Use an overload of {nameof(Minima)} that accepts an async delegate with a {nameof(CancellationToken)} parameter.")]
     public static IExtremaAsyncEnumerable<TSource> MinByAwait<TSource, TKey>(
-        IAsyncEnumerable<TSource> source,
+        this IAsyncEnumerable<TSource> source,
         Func<TSource, ValueTask<TKey>> selector)
     {
         if (source is null) throw new ArgumentNullException(nameof(source));
@@ -108,7 +106,7 @@ static partial class MoreAsyncEnumerable
     /// or <paramref name="comparer"/> is null</exception>
     [Obsolete($"Use an overload of {nameof(Minima)} that accepts an async delegate with a {nameof(CancellationToken)} parameter.")]
     public static IExtremaAsyncEnumerable<TSource> MinByAwait<TSource, TKey>(
-        IAsyncEnumerable<TSource> source,
+        this IAsyncEnumerable<TSource> source,
         Func<TSource, ValueTask<TKey>> selector,
         IComparer<TKey>? comparer)
     {

--- a/tests/MoreAsyncLINQ.Tests/PublicApi/MoreAsyncLINQ.verified.txt
+++ b/tests/MoreAsyncLINQ.Tests/PublicApi/MoreAsyncLINQ.verified.txt
@@ -541,30 +541,26 @@
         [System.Obsolete("Use an overload of LeftJoin that accepts an async delegate with a CancellationTok" +
             "en parameter.")]
         public static System.Collections.Generic.IAsyncEnumerable<TResult> LeftJoinAwait<TFirst, TSecond, TKey, TResult>(this System.Collections.Generic.IAsyncEnumerable<TFirst> first, System.Collections.Generic.IAsyncEnumerable<TSecond> second, System.Func<TFirst, System.Threading.Tasks.ValueTask<TKey>> firstKeySelector, System.Func<TSecond, System.Threading.Tasks.ValueTask<TKey>> secondKeySelector, System.Func<TFirst, System.Threading.Tasks.ValueTask<TResult>> firstSelector, System.Func<TFirst, TSecond, System.Threading.Tasks.ValueTask<TResult>> bothSelector, System.Collections.Generic.IEqualityComparer<TKey>? comparer) { }
-        [System.Obsolete("Use an overload of Maxima.")]
-        public static MoreAsyncLINQ.IExtremaAsyncEnumerable<TSource> MaxBy<TSource, TKey>(System.Collections.Generic.IAsyncEnumerable<TSource> source, System.Func<TSource, TKey> selector) { }
-        [System.Obsolete("Use an overload of Maxima.")]
-        public static MoreAsyncLINQ.IExtremaAsyncEnumerable<TSource> MaxBy<TSource, TKey>(System.Collections.Generic.IAsyncEnumerable<TSource> source, System.Func<TSource, TKey> selector, System.Collections.Generic.IComparer<TKey>? comparer) { }
+        public static MoreAsyncLINQ.IExtremaAsyncEnumerable<TSource> MaxBy<TSource, TKey>(this System.Collections.Generic.IAsyncEnumerable<TSource> source, System.Func<TSource, TKey> selector) { }
+        public static MoreAsyncLINQ.IExtremaAsyncEnumerable<TSource> MaxBy<TSource, TKey>(this System.Collections.Generic.IAsyncEnumerable<TSource> source, System.Func<TSource, TKey> selector, System.Collections.Generic.IComparer<TKey>? comparer) { }
         [System.Obsolete("Use an overload of Maxima that accepts an async delegate with a CancellationToken" +
             " parameter.")]
-        public static MoreAsyncLINQ.IExtremaAsyncEnumerable<TSource> MaxByAwait<TSource, TKey>(System.Collections.Generic.IAsyncEnumerable<TSource> source, System.Func<TSource, System.Threading.Tasks.ValueTask<TKey>> selector) { }
+        public static MoreAsyncLINQ.IExtremaAsyncEnumerable<TSource> MaxByAwait<TSource, TKey>(this System.Collections.Generic.IAsyncEnumerable<TSource> source, System.Func<TSource, System.Threading.Tasks.ValueTask<TKey>> selector) { }
         [System.Obsolete("Use an overload of Maxima that accepts an async delegate with a CancellationToken" +
             " parameter.")]
-        public static MoreAsyncLINQ.IExtremaAsyncEnumerable<TSource> MaxByAwait<TSource, TKey>(System.Collections.Generic.IAsyncEnumerable<TSource> source, System.Func<TSource, System.Threading.Tasks.ValueTask<TKey>> selector, System.Collections.Generic.IComparer<TKey>? comparer) { }
+        public static MoreAsyncLINQ.IExtremaAsyncEnumerable<TSource> MaxByAwait<TSource, TKey>(this System.Collections.Generic.IAsyncEnumerable<TSource> source, System.Func<TSource, System.Threading.Tasks.ValueTask<TKey>> selector, System.Collections.Generic.IComparer<TKey>? comparer) { }
         public static MoreAsyncLINQ.IExtremaAsyncEnumerable<TSource> Maxima<TSource, TKey>(this System.Collections.Generic.IAsyncEnumerable<TSource> source, System.Func<TSource, TKey> selector) { }
         public static MoreAsyncLINQ.IExtremaAsyncEnumerable<TSource> Maxima<TSource, TKey>(this System.Collections.Generic.IAsyncEnumerable<TSource> source, System.Func<TSource, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TKey>> selector) { }
         public static MoreAsyncLINQ.IExtremaAsyncEnumerable<TSource> Maxima<TSource, TKey>(this System.Collections.Generic.IAsyncEnumerable<TSource> source, System.Func<TSource, TKey> selector, System.Collections.Generic.IComparer<TKey>? comparer) { }
         public static MoreAsyncLINQ.IExtremaAsyncEnumerable<TSource> Maxima<TSource, TKey>(this System.Collections.Generic.IAsyncEnumerable<TSource> source, System.Func<TSource, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TKey>> selector, System.Collections.Generic.IComparer<TKey>? comparer) { }
-        [System.Obsolete("Use an overload of Minima.")]
-        public static MoreAsyncLINQ.IExtremaAsyncEnumerable<TSource> MinBy<TSource, TKey>(System.Collections.Generic.IAsyncEnumerable<TSource> source, System.Func<TSource, TKey> selector) { }
-        [System.Obsolete("Use an overload of Minima.")]
-        public static MoreAsyncLINQ.IExtremaAsyncEnumerable<TSource> MinBy<TSource, TKey>(System.Collections.Generic.IAsyncEnumerable<TSource> source, System.Func<TSource, TKey> selector, System.Collections.Generic.IComparer<TKey>? comparer) { }
+        public static MoreAsyncLINQ.IExtremaAsyncEnumerable<TSource> MinBy<TSource, TKey>(this System.Collections.Generic.IAsyncEnumerable<TSource> source, System.Func<TSource, TKey> selector) { }
+        public static MoreAsyncLINQ.IExtremaAsyncEnumerable<TSource> MinBy<TSource, TKey>(this System.Collections.Generic.IAsyncEnumerable<TSource> source, System.Func<TSource, TKey> selector, System.Collections.Generic.IComparer<TKey>? comparer) { }
         [System.Obsolete("Use an overload of Minima that accepts an async delegate with a CancellationToken" +
             " parameter.")]
-        public static MoreAsyncLINQ.IExtremaAsyncEnumerable<TSource> MinByAwait<TSource, TKey>(System.Collections.Generic.IAsyncEnumerable<TSource> source, System.Func<TSource, System.Threading.Tasks.ValueTask<TKey>> selector) { }
+        public static MoreAsyncLINQ.IExtremaAsyncEnumerable<TSource> MinByAwait<TSource, TKey>(this System.Collections.Generic.IAsyncEnumerable<TSource> source, System.Func<TSource, System.Threading.Tasks.ValueTask<TKey>> selector) { }
         [System.Obsolete("Use an overload of Minima that accepts an async delegate with a CancellationToken" +
             " parameter.")]
-        public static MoreAsyncLINQ.IExtremaAsyncEnumerable<TSource> MinByAwait<TSource, TKey>(System.Collections.Generic.IAsyncEnumerable<TSource> source, System.Func<TSource, System.Threading.Tasks.ValueTask<TKey>> selector, System.Collections.Generic.IComparer<TKey>? comparer) { }
+        public static MoreAsyncLINQ.IExtremaAsyncEnumerable<TSource> MinByAwait<TSource, TKey>(this System.Collections.Generic.IAsyncEnumerable<TSource> source, System.Func<TSource, System.Threading.Tasks.ValueTask<TKey>> selector, System.Collections.Generic.IComparer<TKey>? comparer) { }
         public static MoreAsyncLINQ.IExtremaAsyncEnumerable<TSource> Minima<TSource, TKey>(this System.Collections.Generic.IAsyncEnumerable<TSource> source, System.Func<TSource, TKey> selector) { }
         public static MoreAsyncLINQ.IExtremaAsyncEnumerable<TSource> Minima<TSource, TKey>(this System.Collections.Generic.IAsyncEnumerable<TSource> source, System.Func<TSource, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TKey>> selector) { }
         public static MoreAsyncLINQ.IExtremaAsyncEnumerable<TSource> Minima<TSource, TKey>(this System.Collections.Generic.IAsyncEnumerable<TSource> source, System.Func<TSource, TKey> selector, System.Collections.Generic.IComparer<TKey>? comparer) { }


### PR DESCRIPTION
It doesn't conflict with .NET's MaxByAsync, MinByAsync